### PR TITLE
WIP: Edited files to use Email instead of username

### DIFF
--- a/.idea/dataSources.local.xml
+++ b/.idea/dataSources.local.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="dataSourceStorageLocal">
+    <data-source name="MySQL - she3@studentdb-maria.gl.umbc.edu" uuid="4afa4a18-61be-4a3c-af5d-491a262691c1">
+      <database-info product="MySQL" version="5.5.5-10.1.18-MariaDB" jdbc-version="4.0" driver-name="MySQL Connector Java" driver-version="mysql-connector-java-5.1.35 ( Revision: 5fb9c5849535c13917c2cf9baaece6ef9693ef27 )">
+        <extra-name-characters>#@</extra-name-characters>
+        <identifier-quote-string>`</identifier-quote-string>
+      </database-info>
+      <case-sensitivity plain-identifiers="exact" quoted-identifiers="exact" />
+      <secret-storage>master_key</secret-storage>
+      <user-name>she3</user-name>
+      <resolve-scope>information_schema:</resolve-scope>
+    </data-source>
+  </component>
+</project>

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="MySQL - she3@studentdb-maria.gl.umbc.edu" uuid="4afa4a18-61be-4a3c-af5d-491a262691c1">
+      <driver-ref>mysql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://studentdb-maria.gl.umbc.edu:3306/she3</jdbc-url>
+      <driver-properties>
+        <property name="autoReconnect" value="true" />
+        <property name="zeroDateTimeBehavior" value="convertToNull" />
+        <property name="tinyInt1isBit" value="false" />
+        <property name="characterEncoding" value="utf8" />
+        <property name="characterSetResults" value="utf8" />
+        <property name="yearIsDateType" value="false" />
+      </driver-properties>
+    </data-source>
+  </component>
+</project>

--- a/.idea/dataSources/4afa4a18-61be-4a3c-af5d-491a262691c1.xml
+++ b/.idea/dataSources/4afa4a18-61be-4a3c-af5d-491a262691c1.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataSource name="MySQL - she3@studentdb-maria.gl.umbc.edu">
+  <database-model serializer="dbm" rdbms="MYSQL" format-version="2.6">
+    <schema id="1" name="she3">
+      <visible>1</visible>
+    </schema>
+    <schema id="2" name="information_schema"/>
+    <table id="3" parent="1" name="Advisor Data"/>
+    <table id="4" parent="1" name="Appointment"/>
+    <table id="5" parent="1" name="Quiz"/>
+    <table id="6" parent="1" name="Student Data"/>
+    <table id="7" parent="1" name="advisors"/>
+    <table id="8" parent="1" name="appointments"/>
+    <table id="9" parent="1" name="students"/>
+    <column id="10" parent="3" name="ID">
+      <comment>Primary Key</comment>
+      <mandatory>1</mandatory>
+      <data-type>int(11)|0</data-type>
+      <sequence-identity>1</sequence-identity>
+    </column>
+    <column id="11" parent="3" name="StudentID">
+      <comment>in format AA 0000</comment>
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="12" parent="3" name="FirstName">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="13" parent="3" name="LastName">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="14" parent="3" name="Password">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="15" parent="3" name="Office">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <key id="16" parent="3" name="PRIMARY">
+      <columns>ID</columns>
+      <primary>1</primary>
+    </key>
+    <column id="17" parent="4" name="ID">
+      <comment>primary key</comment>
+      <mandatory>1</mandatory>
+      <data-type>int(11)|0</data-type>
+      <sequence-identity>1</sequence-identity>
+    </column>
+    <column id="18" parent="4" name="Location">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="19" parent="4" name="TimeSlot">
+      <mandatory>1</mandatory>
+      <data-type>time|0</data-type>
+    </column>
+    <column id="20" parent="4" name="Day">
+      <mandatory>1</mandatory>
+      <data-type>date|0</data-type>
+    </column>
+    <column id="21" parent="4" name="Major">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="22" parent="4" name="numStudents">
+      <comment>Number of students signed up for an appointment -- set to NULL if none</comment>
+      <data-type>tinyint(3) unsigned|0</data-type>
+      <default-expression>&apos;0&apos;</default-expression>
+    </column>
+    <column id="23" parent="4" name="maxStudents">
+      <data-type>tinyint(3) unsigned|0</data-type>
+    </column>
+    <column id="24" parent="4" name="listOfStudents">
+      <comment>Comma delimitted list of student ID numbers.</comment>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="25" parent="4" name="advisorID">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <key id="26" parent="4" name="PRIMARY">
+      <columns>ID</columns>
+      <primary>1</primary>
+    </key>
+    <column id="27" parent="5" name="count">
+      <mandatory>1</mandatory>
+      <data-type>int(10) unsigned|0</data-type>
+      <sequence-identity>1</sequence-identity>
+    </column>
+    <column id="28" parent="5" name="question">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="29" parent="5" name="type">
+      <mandatory>1</mandatory>
+      <data-type>varchar(2)|0</data-type>
+    </column>
+    <column id="30" parent="5" name="option1">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="31" parent="5" name="option2">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="32" parent="5" name="option3">
+      <data-type>text|0</data-type>
+    </column>
+    <column id="33" parent="5" name="option4">
+      <data-type>text|0</data-type>
+    </column>
+    <column id="34" parent="5" name="option5">
+      <data-type>text|0</data-type>
+    </column>
+    <column id="35" parent="5" name="answer">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <key id="36" parent="5" name="PRIMARY">
+      <columns>count</columns>
+      <primary>1</primary>
+    </key>
+    <column id="37" parent="6" name="ID">
+      <comment>Primary Key</comment>
+      <mandatory>1</mandatory>
+      <data-type>int(11)|0</data-type>
+      <sequence-identity>1</sequence-identity>
+    </column>
+    <column id="38" parent="6" name="StudentID">
+      <comment>in format AA 0000</comment>
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="39" parent="6" name="FirstName">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="40" parent="6" name="LastName">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="41" parent="6" name="Password">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="42" parent="6" name="ApptNum">
+      <comment>NULL if no appointment scheduled</comment>
+      <data-type>smallint(6)|0</data-type>
+    </column>
+    <column id="43" parent="6" name="Major">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="44" parent="6" name="Email">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <key id="45" parent="6" name="PRIMARY">
+      <columns>ID</columns>
+      <primary>1</primary>
+    </key>
+    <column id="46" parent="7" name="Email">
+      <data-type>text|0</data-type>
+    </column>
+    <column id="47" parent="7" name="id">
+      <mandatory>1</mandatory>
+      <data-type>int(11)|0</data-type>
+      <sequence-identity>1</sequence-identity>
+    </column>
+    <column id="48" parent="7" name="fullName">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="49" parent="7" name="Office">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="50" parent="7" name="Password">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <index id="51" parent="7" name="id">
+      <columns>id</columns>
+      <desc-columns></desc-columns>
+    </index>
+    <key id="52" parent="7" name="PRIMARY">
+      <columns>id</columns>
+      <primary>1</primary>
+    </key>
+    <column id="53" parent="8" name="id">
+      <mandatory>1</mandatory>
+      <data-type>int(11)|0</data-type>
+      <sequence-identity>1</sequence-identity>
+    </column>
+    <column id="54" parent="8" name="Advisor">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="55" parent="8" name="NumStudents">
+      <mandatory>1</mandatory>
+      <data-type>tinyint(4)|0</data-type>
+    </column>
+    <column id="56" parent="8" name="Date">
+      <mandatory>1</mandatory>
+      <data-type>varchar(10)|0</data-type>
+    </column>
+    <column id="57" parent="8" name="Time">
+      <mandatory>1</mandatory>
+      <data-type>varchar(5)|0</data-type>
+    </column>
+    <column id="58" parent="8" name="isGroup">
+      <mandatory>1</mandatory>
+      <data-type>tinyint(1)|0</data-type>
+    </column>
+    <column id="59" parent="8" name="isFull">
+      <mandatory>1</mandatory>
+      <data-type>tinyint(1)|0</data-type>
+    </column>
+    <column id="60" parent="8" name="Location">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="61" parent="8" name="AdvisorUsername">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <key id="62" parent="8" name="PRIMARY">
+      <columns>id</columns>
+      <primary>1</primary>
+    </key>
+    <column id="63" parent="9" name="Username">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="64" parent="9" name="email">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="65" parent="9" name="Major">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="66" parent="9" name="Appt">
+      <data-type>int(11)|0</data-type>
+    </column>
+    <column id="67" parent="9" name="id">
+      <mandatory>1</mandatory>
+      <data-type>int(11)|0</data-type>
+      <sequence-identity>1</sequence-identity>
+    </column>
+    <column id="68" parent="9" name="firstName">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="69" parent="9" name="lastName">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <column id="70" parent="9" name="studentID">
+      <mandatory>1</mandatory>
+      <data-type>varchar(9)|0</data-type>
+    </column>
+    <column id="71" parent="9" name="Password">
+      <mandatory>1</mandatory>
+      <data-type>text|0</data-type>
+    </column>
+    <index id="72" parent="9" name="id">
+      <columns>id</columns>
+      <desc-columns></desc-columns>
+    </index>
+    <key id="73" parent="9" name="PRIMARY">
+      <columns>id</columns>
+      <primary>1</primary>
+    </key>
+  </database-model>
+</dataSource>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="file://$PROJECT_DIR$" dialect="MySQL" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,11 +2,18 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="7820db9e-3f28-4a99-b973-c6861eae8036" name="Default" comment="">
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/misc.xml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/vcs.xml" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/index.php" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/html/header.html" afterPath="$PROJECT_DIR$/html/header.html" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/html/standard.css" afterPath="$PROJECT_DIR$/html/standard.css" />
+      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/dataSources.xml" />
+      <change type="MOVED" beforePath="$PROJECT_DIR$/php/validate/validate_advisor.php" afterPath="$PROJECT_DIR$/php/validate/validate_advisor_register.php" />
+      <change type="MOVED" beforePath="$PROJECT_DIR$/php/validate/validate_student.php" afterPath="$PROJECT_DIR$/php/validate/validate_student_register.php" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/workspace.xml" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/html/forms/add_appointment.html" afterPath="$PROJECT_DIR$/html/forms/add_appointment.html" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/html/forms/login_advisor.html" afterPath="$PROJECT_DIR$/html/forms/login_advisor.html" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/html/forms/login_student.html" afterPath="$PROJECT_DIR$/html/forms/login_student.html" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/html/forms/register_advisor.html" afterPath="$PROJECT_DIR$/html/forms/register_advisor.html" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/html/forms/register_student.html" afterPath="$PROJECT_DIR$/html/forms/register_student.html" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/php/validate/validate_advisor_login.php" afterPath="$PROJECT_DIR$/php/validate/validate_advisor_login.php" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/php/validate/validate_appointment.php" afterPath="$PROJECT_DIR$/php/validate/validate_appointment.php" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/php/validate/validate_student_login.php" afterPath="$PROJECT_DIR$/php/validate/validate_student_login.php" />
     </list>
     <ignored path="proj2.iws" />
     <ignored path=".idea/workspace.xml" />
@@ -21,60 +28,120 @@
   <component name="CreatePatchCommitExecutor">
     <option name="PATCH_PATH" value="" />
   </component>
+  <component name="DatabaseView">
+    <option name="GROUP_SCHEMA" value="true" />
+    <option name="GROUP_CONTENTS" value="false" />
+    <option name="SORT_POSITIONED" value="false" />
+    <option name="SHOW_TABLE_DETAILS" value="true" />
+    <option name="SHOW_EMPTY_GROUPS" value="false" />
+    <option name="AUTO_SCROLL_FROM_SOURCE" value="false" />
+    <PATH>
+      <PATH_ELEMENT>
+        <option name="myItemId" />
+        <option name="myItemType" value="com.intellij.database.view.DatabaseStructure$Root" />
+      </PATH_ELEMENT>
+    </PATH>
+  </component>
   <component name="ExecutionTargetManager" SELECTED_TARGET="default_target" />
   <component name="FavoritesManager">
     <favorites_list name="proj2" />
   </component>
   <component name="FileEditorManager">
-    <leaf>
-      <file leaf-file-name="first_page.html" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/html/forms/first_page.html">
+    <leaf SIDE_TABS_SIZE_LIMIT_KEY="450">
+      <file leaf-file-name="login_advisor.html" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/html/forms/login_advisor.html">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="442">
-              <caret line="20" column="0" selection-start-line="20" selection-start-column="0" selection-end-line="20" selection-end-column="28" />
+            <state relative-caret-position="182">
+              <caret line="7" column="48" selection-start-line="7" selection-start-column="48" selection-end-line="7" selection-end-column="48" />
               <folding />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="index.php" pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/index.php">
+      <file leaf-file-name="register_advisor.html" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/html/forms/register_advisor.html">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="208">
-              <caret line="8" column="4" selection-start-line="8" selection-start-column="4" selection-end-line="8" selection-end-column="4" />
+            <state relative-caret-position="234">
+              <caret line="9" column="86" selection-start-line="9" selection-start-column="60" selection-end-line="9" selection-end-column="86" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="register_student.html" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/html/forms/register_student.html">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="416">
+              <caret line="16" column="49" selection-start-line="16" selection-start-column="49" selection-end-line="16" selection-end-column="49" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="validate_student_register.php" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/php/validate/validate_student_register.php">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="312">
+              <caret line="96" column="107" selection-start-line="96" selection-start-column="107" selection-end-line="96" selection-end-column="129" />
               <folding>
-                <element signature="e#6#90#0#PHP" expanded="true" />
+                <marker date="1480280386794" expanded="true" signature="212:241" ph="SELECT Usern... students" />
+                <marker date="1480280386794" expanded="true" signature="2254:2389" ph="INSERT INTO `students`... " />
               </folding>
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="standard.css" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/html/standard.css">
+      <file leaf-file-name="validate_advisor_register.php" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/php/validate/validate_advisor_register.php">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="52">
-              <caret line="2" column="27" selection-start-line="2" selection-start-column="27" selection-end-line="2" selection-end-column="27" />
+            <state relative-caret-position="806">
+              <caret line="31" column="70" selection-start-line="31" selection-start-column="70" selection-end-line="31" selection-end-column="70" />
+              <folding>
+                <marker date="1480280447615" expanded="true" signature="149:175" ph="SELECT Email... advisors" />
+                <marker date="1480280447615" expanded="true" signature="1671:1737" ph="INSERT INTO `advisors`... " />
+                <marker date="1480280447615" expanded="true" signature="1671:1769" ph="INSERT INTO `advisors`... " />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="validate_student_login.php" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/php/validate/validate_student_login.php">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="106">
+              <caret line="29" column="32" selection-start-line="29" selection-start-column="32" selection-end-line="29" selection-end-column="32" />
+              <folding>
+                <marker date="1480280106460" expanded="true" signature="323:405" ph="SELECT * FRO... students" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="add_appointment.html" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/html/forms/add_appointment.html">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="1040">
+              <caret line="40" column="0" selection-start-line="40" selection-start-column="0" selection-end-line="40" selection-end-column="0" />
               <folding />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="header.html" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/html/header.html">
+      <file leaf-file-name="validate_appointment.php" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/php/validate/validate_appointment.php">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="52">
-              <caret line="2" column="30" selection-start-line="2" selection-start-column="30" selection-end-line="2" selection-end-column="30" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="footer.html" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/html/footer.html">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="0">
-              <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-              <folding />
+            <state relative-caret-position="364">
+              <caret line="14" column="19" selection-start-line="14" selection-start-column="19" selection-end-line="14" selection-end-column="20" />
+              <folding>
+                <marker date="1480281280925" expanded="true" signature="362:423" ph="SELECT Date,... appointments" />
+                <marker date="1480281280925" expanded="true" signature="362:424" ph="SELECT Date,... appointments" />
+                <marker date="1480281280925" expanded="true" signature="362:432" ph="SELECT Date,... appointments" />
+                <marker date="1480281280925" expanded="true" signature="1752:1806" ph="SELECT fullN... advisors" />
+                <marker date="1480281280925" expanded="true" signature="1752:1807" ph="SELECT fullN... advisors" />
+                <marker date="1480281280925" expanded="true" signature="1982:2073" ph="INSERT INTO appointments... " />
+                <marker date="1480281280925" expanded="true" signature="1982:2083" ph="INSERT INTO appointments... " />
+                <marker date="1480281280925" expanded="true" signature="1982:2108" ph="INSERT INTO appointments... " />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -99,6 +166,18 @@
         <option value="$PROJECT_DIR$/html/header.html" />
         <option value="$PROJECT_DIR$/index.html" />
         <option value="$PROJECT_DIR$/index.php" />
+        <option value="$APPLICATION_CONFIG_DIR$/consoles/db/4afa4a18-61be-4a3c-af5d-491a262691c1/console.sql" />
+        <option value="$PROJECT_DIR$/php/validate/validate_advisor.php" />
+        <option value="$PROJECT_DIR$/html/forms/register_student.html" />
+        <option value="$PROJECT_DIR$/html/forms/register_advisor.html" />
+        <option value="$PROJECT_DIR$/html/forms/login_student.html" />
+        <option value="$PROJECT_DIR$/php/validate/validate_advisor_login.php" />
+        <option value="$PROJECT_DIR$/html/forms/login_advisor.html" />
+        <option value="$PROJECT_DIR$/php/validate/validate_student_login.php" />
+        <option value="$PROJECT_DIR$/php/validate/validate_student_register.php" />
+        <option value="$PROJECT_DIR$/php/validate/validate_advisor_register.php" />
+        <option value="$PROJECT_DIR$/html/forms/add_appointment.html" />
+        <option value="$PROJECT_DIR$/php/validate/validate_appointment.php" />
       </list>
     </option>
   </component>
@@ -140,6 +219,7 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
+      <pane id="Scratches" />
       <pane id="ProjectPane">
         <subPane>
           <PATH>
@@ -168,13 +248,80 @@
               <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
             </PATH_ELEMENT>
             <PATH_ELEMENT>
+              <option name="myItemId" value="php" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="proj2" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="proj2" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="php" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="validate" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="proj2" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="proj2" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
               <option name="myItemId" value="html" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="proj2" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="proj2" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="html" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="forms" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="proj2" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="proj2" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="html" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="error_forms" />
               <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
             </PATH_ELEMENT>
           </PATH>
         </subPane>
       </pane>
-      <pane id="Scratches" />
       <pane id="Scope" />
     </panes>
   </component>
@@ -182,6 +329,7 @@
     <property name="WebServerToolWindowFactoryState" value="false" />
     <property name="DefaultHtmlFileTemplate" value="HTML File" />
     <property name="js-jscs-nodeInterpreter" value="C:\Program Files\nodejs\node.exe" />
+    <property name="com.intellij.database.dataSource.DataSourceTemplate" value="MySQL" />
   </component>
   <component name="RunManager">
     <configuration default="true" type="JavascriptDebugType" factoryName="JavaScript Debug">
@@ -202,6 +350,12 @@
       <method />
     </configuration>
     <configuration default="true" type="js.build_tools.gulp" factoryName="Gulp.js">
+      <node-interpreter>project</node-interpreter>
+      <node-options />
+      <gulpfile />
+      <tasks />
+      <arguments />
+      <envs />
       <method />
     </configuration>
     <configuration default="true" type="js.build_tools.npm" factoryName="npm">
@@ -236,33 +390,35 @@
       <option name="presentableId" value="Default" />
       <updated>1479845346197</updated>
       <workItem from="1479845347661" duration="1439000" />
+      <workItem from="1480275122601" duration="5840000" />
     </task>
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="1439000" />
+    <option name="totallyTimeSpent" value="7279000" />
   </component>
   <component name="ToolWindowManager">
     <frame x="-11" y="-11" width="2582" height="1402" extended-state="6" />
     <editor active="true" />
     <layout>
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.24979919" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
-      <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
-      <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="true" content_ui="tabs" />
-      <window_info id="Database" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
-      <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Database Console" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.32972524" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.25301206" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
+      <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="8" side_tool="true" content_ui="tabs" />
+      <window_info id="Database" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+      <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="9" side_tool="false" content_ui="tabs" />
+      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
       <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
-      <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
-      <window_info id="Favorites" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="true" content_ui="tabs" />
-      <window_info id="Cvs" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
-      <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
-      <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="10" side_tool="false" content_ui="tabs" />
+      <window_info id="Favorites" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="true" content_ui="tabs" />
+      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
+      <window_info id="Cvs" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Commander" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
-      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
-      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
-      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
+      <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
+      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Ant Build" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
-      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
     </layout>
   </component>
   <component name="Vcs.Log.UiProperties">
@@ -281,7 +437,41 @@
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/html/forms/login_advisor.html">
+    <entry file="file://$PROJECT_DIR$/html/forms/first_page.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="520">
+          <caret line="20" column="0" selection-start-line="20" selection-start-column="0" selection-end-line="20" selection-end-column="28" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/index.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding>
+            <element signature="e#6#90#0#PHP" expanded="false" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/html/standard.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="52">
+          <caret line="2" column="27" selection-start-line="2" selection-start-column="27" selection-end-line="2" selection-end-column="27" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/html/header.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="52">
+          <caret line="2" column="30" selection-start-line="2" selection-start-column="30" selection-end-line="2" selection-end-column="30" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/html/footer.html">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
@@ -297,22 +487,7 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/index.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/html/forms/first_page.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="442">
-          <caret line="20" column="0" selection-start-line="20" selection-start-column="0" selection-end-line="20" selection-end-column="28" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
+    <entry file="file://$PROJECT_DIR$/index.html" />
     <entry file="file://$PROJECT_DIR$/html/standard.css">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="52">
@@ -334,7 +509,131 @@
         <state relative-caret-position="208">
           <caret line="8" column="4" selection-start-line="8" selection-start-column="4" selection-end-line="8" selection-end-column="4" />
           <folding>
-            <element signature="e#6#90#0#PHP" expanded="true" />
+            <element signature="e#6#90#0#PHP" expanded="false" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/html/forms/first_page.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="273">
+          <caret line="20" column="0" selection-start-line="20" selection-start-column="0" selection-end-line="20" selection-end-column="28" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/Database/eversam1.sql">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="104">
+          <caret line="4" column="36" selection-start-line="4" selection-start-column="9" selection-end-line="4" selection-end-column="36" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$APPLICATION_CONFIG_DIR$/consoles/db/4afa4a18-61be-4a3c-af5d-491a262691c1/console.sql">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="53" selection-start-line="0" selection-start-column="53" selection-end-line="0" selection-end-column="53" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/html/forms/register_student.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="416">
+          <caret line="16" column="49" selection-start-line="16" selection-start-column="49" selection-end-line="16" selection-end-column="49" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/html/forms/register_advisor.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="234">
+          <caret line="9" column="86" selection-start-line="9" selection-start-column="60" selection-end-line="9" selection-end-column="86" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/html/forms/login_advisor.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="182">
+          <caret line="7" column="48" selection-start-line="7" selection-start-column="48" selection-end-line="7" selection-end-column="48" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/php/validate/validate_advisor_login.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="502">
+          <caret line="38" column="12" selection-start-line="38" selection-start-column="12" selection-end-line="38" selection-end-column="12" />
+          <folding>
+            <marker date="1480280004608" expanded="true" signature="379:459" ph="SELECT * FRO... advisors" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/html/forms/login_student.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="338">
+          <caret line="13" column="4" selection-start-line="13" selection-start-column="4" selection-end-line="13" selection-end-column="4" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/php/validate/validate_student_register.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="312">
+          <caret line="96" column="107" selection-start-line="96" selection-start-column="107" selection-end-line="96" selection-end-column="129" />
+          <folding>
+            <marker date="1480280386794" expanded="true" signature="212:241" ph="SELECT Usern... students" />
+            <marker date="1480280386794" expanded="true" signature="2254:2389" ph="INSERT INTO `students`... " />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/php/validate/validate_advisor_register.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="806">
+          <caret line="31" column="70" selection-start-line="31" selection-start-column="70" selection-end-line="31" selection-end-column="70" />
+          <folding>
+            <marker date="1480280447615" expanded="true" signature="149:175" ph="SELECT Email... advisors" />
+            <marker date="1480280447615" expanded="true" signature="1671:1737" ph="INSERT INTO `advisors`... " />
+            <marker date="1480280447615" expanded="true" signature="1671:1769" ph="INSERT INTO `advisors`... " />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/php/validate/validate_student_login.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="106">
+          <caret line="29" column="32" selection-start-line="29" selection-start-column="32" selection-end-line="29" selection-end-column="32" />
+          <folding>
+            <marker date="1480280106460" expanded="true" signature="323:405" ph="SELECT * FRO... students" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/html/forms/add_appointment.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1040">
+          <caret line="40" column="0" selection-start-line="40" selection-start-column="0" selection-end-line="40" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/php/validate/validate_appointment.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="364">
+          <caret line="14" column="19" selection-start-line="14" selection-start-column="19" selection-end-line="14" selection-end-column="20" />
+          <folding>
+            <marker date="1480281280925" expanded="true" signature="362:423" ph="SELECT Date,... appointments" />
+            <marker date="1480281280925" expanded="true" signature="362:424" ph="SELECT Date,... appointments" />
+            <marker date="1480281280925" expanded="true" signature="362:432" ph="SELECT Date,... appointments" />
+            <marker date="1480281280925" expanded="true" signature="1752:1806" ph="SELECT fullN... advisors" />
+            <marker date="1480281280925" expanded="true" signature="1752:1807" ph="SELECT fullN... advisors" />
+            <marker date="1480281280925" expanded="true" signature="1982:2073" ph="INSERT INTO appointments... " />
+            <marker date="1480281280925" expanded="true" signature="1982:2083" ph="INSERT INTO appointments... " />
+            <marker date="1480281280925" expanded="true" signature="1982:2108" ph="INSERT INTO appointments... " />
           </folding>
         </state>
       </provider>

--- a/html/forms/add_appointment.html
+++ b/html/forms/add_appointment.html
@@ -5,36 +5,36 @@
     <h1>Add an appointment </h1>
     <form method=post action="../../php/validate/validate_appointment.php">
     <!-- Gets the necessary information about the appontment, date, time, location, group --> 
-    <p>Date: <input type=date name="date"/></p>
-    <p>
+    <label>Date: <input type="date" name="date" required/></label> <br>
       <!-- Time is restricted to only having the times between 8:00am and 4:30 pm selected in 30 minutes increments -->
-      Time: <select name="time">
-	<option value="08:00" selected>08:00am</option>
-	<option value="08:30">08:30am</option>
-	<option value="09:00">09:00am</option>
-	<option value="09:30">09:30am</option>
-	<option value="10:00">10:00am</option>
-	<option value="10:30">10:30am</option>
-	<option value="11:00">11:00am</option>
-	<option value="11:30">11:30am</option>
-	<option value="12:00">12:00pm</option>
-	<option value="12:30">12:30pm</option>
-	<option value="13:00">01:00pm</option>
-	<option value="13:30">01:30pm</option>
-	<option value="14:00">02:00pm</option>
-	<option value="14:30">02:30pm</option>
-	<option value="15:00">03:00pm</option>
-	<option value="15:30">03:30pm</option>
-	<option value="16:00">04:00pm</option>
-	<option value="16:30">04:30pm</option>
-      </select>
-    </p>
-    <p>Location: <input type=text name="location"/></p>
-    <p>Group? <select name="group">
+    <label>  Time: <select name="time">
+		<option value="08:00" selected>08:00am</option>
+		<option value="08:30">08:30am</option>
+		<option value="09:00">09:00am</option>
+		<option value="09:30">09:30am</option>
+		<option value="10:00">10:00am</option>
+		<option value="10:30">10:30am</option>
+		<option value="11:00">11:00am</option>
+		<option value="11:30">11:30am</option>
+		<option value="12:00">12:00pm</option>
+		<option value="12:30">12:30pm</option>
+		<option value="13:00">01:00pm</option>
+		<option value="13:30">01:30pm</option>
+		<option value="14:00">02:00pm</option>
+		<option value="14:30">02:30pm</option>
+		<option value="15:00">03:00pm</option>
+		<option value="15:30">03:30pm</option>
+		<option value="16:00">04:00pm</option>
+		<option value="16:30">04:30pm</option>
+	</select></label>
+
+
+    <label>Location: <input type=text name="location" required/></label>
+    <label>Group? <select name="group" required>
 	<option value=1 selected>Yes</option>
 	<option value=0>No</option>
       </select>
-    </p>
+    </label>
     <p><input type=submit value="Submit"/></p>
     </form>
 <?php require('footer.html'); ?>

--- a/html/forms/login_advisor.html
+++ b/html/forms/login_advisor.html
@@ -5,9 +5,9 @@
 <h1>Advisor Login</h1>
     <form method=post action='../../php/validate/validate_advisor_login.php'>
       <!-- Gets the necessary data, a username and password from the user --> 
-      <p>Username: <input type=text name="username"/></p>
-      <p>Password: <input type=password name="password"/></p>
-      <p><input type=submit value="Submit"/></p>
+      <label>Email: <input type=text name="email" pattern="[A-Za-z0-9._+-]+@umbc\.edu" required/></label><br>
+      <label>Password: <input type=password name="password" required/></label><br>
+      <input type=submit value="Submit"/>
     </form>
 	
 <?php include ('footer.html'); ?>

--- a/html/forms/login_student.html
+++ b/html/forms/login_student.html
@@ -5,10 +5,12 @@
 <h1>Student Login</h1>
     <form method=post action='../../php/validate/validate_student_login.php'>
       <!-- Gets the necessary data, a username and password from the user --> 
-      <p>Username: <input type=text name="username"/></p>
-      <p>Password: <input type=password name="password"/></p>
-      <p><input type=submit value="Submit"/></p>
+      <label>Email: <input type=text name="email" pattern="[A-Za-z0-9._+-]+@umbc\.edu" required /></label><br>
+      <label>Password: <input type=password name="password" required /></label><br>
+      <label><input type=submit value="Submit"/></label>
     </form>
+
+    <br>
 	
         <!-- Hyperlink to the register students page -->   
 	<p> Not signed up? Click <a href = "register_student.html">here</a> to register.</p>

--- a/html/forms/register_advisor.html
+++ b/html/forms/register_advisor.html
@@ -5,14 +5,14 @@
 
 <?php require('../header.html'); ?>
     <h1>Advisor Registration</h1>
-    <form method=post action='../../php/validate/validate_advisor.php'>
+    <form method=post action='../../php/validate/validate_advisor_register.php'>
       <!-- Gets information from the potential advisor, username, first name, last name, office, password --> 
-      <p>Username: <input type=text name="username"/></p>
-	  <p>First Name: <input type=text name="fName"/></p>
-	  <p>Last Name: <input type=text name="lName"/></p>
-	  <p>Office: <input type=text name="office"/></p>
-	  <p>Password: <input type=password name="password"/></p>
-	  <p>Retype Password: <input type=password name="rePassword"/></p>
-      <p><input type=submit value="Submit"/></p>
+      <label>Email: <input type=text name="email"  pattern="[A-Za-z0-9._+-]+@umbc\.edu" required/></label><br>
+	  <label>First Name: <input type=text name="fName" required /></label><br>
+	  <label>Last Name: <input type=text name="lName" required /></label><br>
+	  <label>Office: <input type=text name="office" required /></label><br>
+	  <label>Password: <input type=password name="password" required /></label><br>
+	  <label>Retype Password: <input type=password name="rePassword" required /></label><br>
+      <input type=submit value="Submit"/>
     </form>
 <?php require('../footer.html'); ?>

--- a/html/forms/register_student.html
+++ b/html/forms/register_student.html
@@ -5,17 +5,16 @@
 
 <?php require('../header.html'); ?>
     <h1>Student Registration</h1>
-    <form method=post action='../../php/validate/validate_student.php'>
+    <form method=post action='../../php/validate/validate_student_register.php'>
       <!-- Gets information from the potential student, username, major, etc. --> 
-      <p>Username: <input type=text name="username"/></p>
-      <p>First Name: <input type=text name="firstName"/></p>
-      <p>Last Name: <input type=text name="lastName"/></p>
-      <p>Student ID: <input type=text name="studentID"/></p>
-      <p>UMBC Email: <input type=text name="email"/></p>
-      <p>Password: <input type=password name="password"/></p>
-      <p>Retype Password: <input type=password name="rePassword"/></p>
+      <label>Email: <input type=text name="email" pattern="[A-Za-z0-9._+-]+@umbc\.edu" required/></label>
+      <label>First Name: <input type=text name="firstName" required /></label>
+      <label>Last Name: <input type=text name="lastName" required /></label>
+      <label>Student ID: <input type=text name="studentID" required /></label>
+      <label>Password: <input type=password name="password" required /></label>
+      <label>Retype Password: <input type=password name="rePassword" required /></label>
      
-      <p>Major: <select name="major">
+      <label>Major: <select name="major" required>
 	  
 	  <!-- This creates a drop down box of the possible major choices -->
 	  <option value = "Biological Sciences BA">Biological Sciences BA</option>
@@ -31,9 +30,9 @@
 
 	  
 	  </select>
-	  </p>
+	  </labeL>
 	  
-      <p><input type=submit value="Submit"/></p>
+      <input type=submit value="Submit"/>
     </form>
 	
     	<!-- Hyperlink to the login student page -->

--- a/php/validate/validate_advisor_login.php
+++ b/php/validate/validate_advisor_login.php
@@ -5,12 +5,12 @@
 
 require_once('../mysql_connect.php');
 
-$username = $_POST['username'];
+$email = $_POST['email'];
 $password = ($_POST['password']);
 $truePassword = md5($password);
 
 // Make the query to get the info out of advisors table
-$sql = "SELECT * FROM `advisors` WHERE `Username` = '$username' AND `Password` = '$truePassword'";
+$sql = "SELECT * FROM advisors WHERE `Email` = '$email' AND `Password` = '$truePassword'";
 $rs = mysql_query($sql, $conn);
 $name_found = False;
 $error_message  = "";
@@ -28,7 +28,7 @@ if($num_rows == 1){
 if ($name_found) 
 {
   session_start();		
-  $_SESSION['username'] = $_POST['username'];
+  $_SESSION['username'] = $email;
   header('Location:../../php/view/advisor_view.php');
 } 
 
@@ -36,15 +36,19 @@ if ($name_found)
 else
 {
   // Username field left blank
-  if ($_POST['username'] == "") 
+  if ($email == "")
   {
-    $error_message .= "Username field can't be blank.<br>";
+    $error_message .= "Email field can't be blank.<br>";
+  }
+
+  elseif (preg_match("/^[A-Za-z0-9._+-]+@umbc\.edu$/", $email)) {
+    $error_message .= "Email is not a valid UMBC email.<br>";
   }
 
   // Username does not exist in the table OR password is incorrect
   else 
   {
-    $error_message = "Username or password not recognized.<br>";
+    $error_message = "Email or password not recognized.<br>";
   } 
   
   include('../../html/error_forms/advisor_login_error.html');

--- a/php/validate/validate_advisor_register.php
+++ b/php/validate/validate_advisor_register.php
@@ -4,7 +4,7 @@
 <?php
 require_once('../mysql_connect.php');
 
-$sql = "SELECT username FROM advisors";
+$sql = "SELECT Email FROM advisors";
 $rs = mysql_query($sql, $conn);
 
 //By default no errors
@@ -12,21 +12,27 @@ $errors = False;
 $error_message = "";
 
 //Loop through usernames, check for match
-while($username = mysql_fetch_array($rs)) 
+while($existing = mysql_fetch_array($rs))
 {
-  if ($_POST['username'] == $username['username']) 
+  if ($_POST['email'] == $existing['Email'])
   {
     //Match found - BAD - there is an error
     $errors = True;
-    $error_message = "Username already taken<br>";
+    $error_message = "Email already taken<br>";
   }
 }
 
 //Username left blank check
-if ($_POST['username'] == "") 
+if ($_POST['email'] == "")
 {
     $errors = True;
-    $error_message .= "Username field can't be blank.<br>";
+    $error_message .= "Email field can't be blank.<br>";
+}
+
+elseif (preg_match("/^[A-Za-z0-9._+-]+@umbc\.edu$/", $_POST['email']))
+{
+    $errors = True;
+    $error_message .= "Not a valid UMBC Email Address<br>";
 }
 
 //First name left blank check
@@ -61,15 +67,19 @@ if ($errors != True)
 {
   //No errors - GOOD - Insert into database
   $fullName = $_POST['fName'] . " " . $_POST['lName'];
-  $uName = $_POST['username'];
+  $email = $_POST['email'];
   $office = $_POST['office'];
   $password = $_POST['password'];
+    $hashedPass = md5($password);
+
+    $queryFormat = "INSERT INTO `advisors` (`Email`, `fullName`, `Office`, `Password`) VALUES ('%s', '%s', '%s', '%s')";
+
+    $queryBuilt = sprintf($queryFormat, $email, $fullName, $office, $hashedPass);
   
-  $sql = "insert into `advisors` (`Username`, `id`, `fullName`, `Office`, `Password`) values ('$uName', NULL, '$fullName', '$office', '".md5($password)."'); 
-  $rs = mysql_query($sql, $conn);
+  $rs = mysql_query($queryBuilt, $conn);
   
   session_start();
-  $_SESSION['username'] = $_POST['username'];
+  $_SESSION['username'] = $_POST['email'];
   header('Location:../../php/view/advisor_view.php');
 }
 else

--- a/php/validate/validate_appointment.php
+++ b/php/validate/validate_appointment.php
@@ -6,10 +6,12 @@
 require_once('../mysql_connect.php');
 session_start();
 
+$email = $_SESSION['username'];
+
 // Creates the query to get the information from the appointments database where the username is equal to the current session username
-$sql = "SELECT Date, Time FROM appointments WHERE AdvisorUsername = \"". $_SESSION['username'] . "\"";
+$sql = "SELECT Date, Time FROM appointments WHERE `AdvisorUsername` = '$email'";
 $rs = mysql_query($sql, $conn);
-$errors = "False";
+$errors = False;
 $error_message = "";
 
 // Set the time zone to the east coast 
@@ -59,19 +61,21 @@ if ($location == "")
 }
 
 // If there are errors 
-if($errors != "True")
+if(!$errors)
 {
   // Get the information from the advisors database for the fullName
   // This will be used in the next query 
-  $sql = "SELECT fullName FROM advisors WHERE Username = \"" . $_SESSION['username'] . "\"";
+  $sql = "SELECT fullName FROM advisors WHERE `Email` = '$email'";
   $rs = mysql_query($sql, $conn);
   $fullName = mysql_fetch_array($rs)['fullName'];
 
   echo $sql;
-	
+
   // Insert a new appointment into the appointments table
-  $sql = "INSERT INTO appointments (Date, Time, Location, isGroup, Advisor, AdvisorUsername) VALUES (\"" . $date . "\", \"" . $time . "\", \"" . $location . "\", " . $group . ", \"" . $fullName . "\", \"" . $_SESSION['username'] . "\")";                    
-  $rs = mysql_query($sql, $conn);
+  $sql =
+      "INSERT INTO appointments (Date, Time, Location, isGroup, Advisor, AdvisorUsername) VALUES ('%s', '%s', '%s', '%s', '%s', '%s')";
+  $formatted = sprintf($sql, $date, $time, $location, $group, $fullName, $email);
+  $rs = mysql_query($formatted, $conn);
 
   // Go back to the advisor_view.php 
   header('Location:../view/advisor_view.php');

--- a/php/validate/validate_student_login.php
+++ b/php/validate/validate_student_login.php
@@ -5,12 +5,12 @@
 
 require_once('../mysql_connect.php');
 
-$username = $_POST['username'];
+$email = $_POST['email'];
 $password = ($_POST['password']);
 $truePassword = md5($password);
 
 // Make the query to get the info out of advisors table
-$sql = "SELECT * FROM `students` WHERE `Username` = '$username' AND `Password` = '$truePassword'";
+$sql = "SELECT * FROM `students` WHERE `Email` = '$email' AND `Password` = '$truePassword'";
 $rs = mysql_query($sql, $conn);
 $name_found = False;
 $error_message  = "";
@@ -27,7 +27,7 @@ if($num_rows == 1){
 if ($name_found) 
 {
   session_start();
-  $_SESSION['username'] = $_POST['username'];
+  $_SESSION['username'] = $email;
 
   // go to the student_view.php page
   header('Location:../../php/view/student_view.php');
@@ -37,7 +37,7 @@ if ($name_found)
 else
 {
   // Check if the username was left blank
-  if ($_POST['username'] == "") 
+  if ($email == "")
   {
     $error_message .= "Username field can't be blank.<br>";
   }

--- a/php/validate/validate_student_register.php
+++ b/php/validate/validate_student_register.php
@@ -14,13 +14,13 @@ $error_message = "";
 $other_print = "";
 
 //Loop through usernames, check for match
-while($username = mysql_fetch_array($rs)) 
+while($existing = mysql_fetch_array($rs))
 {
-  if ($_POST['username'] == $username['Username']) 
+  if ($_POST['email'] == $existing['Email'])
   {
     //Match found - BAD - there is an error
     $errors = True;
-    $error_message = "Username already taken<br>";
+    $error_message = "Email already taken<br>";
     break;
   }
 }
@@ -29,7 +29,10 @@ while($username = mysql_fetch_array($rs))
 if ($_POST['username'] == "") 
 {
   $errors = True;
-  $error_message .= "Username field can't be blank.<br>";
+  $error_message .= "Email field can't be blank.<br>";
+} elseif (preg_match("/^[A-Za-z0-9._+-]+@umbc\.edu$/", $_POST['email'])) {
+    $errors = True;
+    $error_message .= "Not a valid UMBC Email<br>";
 }
 
 //Major left blank check
@@ -82,19 +85,24 @@ if ($_POST['password'] == $_POST['rePassword'])
 if ($errors != True) 
 {
   //No errors - GOOD - Insert into database
-  $uName = $_POST['username'];
   $email = $_POST['email'];
   $major = $_POST['major'];
   $fName = $_POST['fName'];
   $lName = $_POST['lName'];
-  $studentID = $_POST['studentID']
+  $studentID = $_POST['studentID'];
   $password = $_POST['password'];
- 
-  $sql = "insert into `students` (`Username`, `email`, `Major`, `Appt`, `id`, `firstName`, `lastName`, `studentID`, `Password`) values ('$uName', '$email', '$major', NULL, NULL, '$fName', '$lName', '$studentID', '".md5($password)."'); 
-  $rs = mysql_query($sql, $conn);
- 
+  $hashedPass = md5($password);
+
+  $queryFormat =
+      "INSERT INTO `students` (`Email`, `Major`, `firstName`, `lastName`, `studentID`, `Password`) VALUES ('%s', '%s', '%s', '%s', '%s', '%s')";
+
+  $queryBuilt =
+      sprintf($queryFormat, $email, $major, $fName, $lName, $studentID, $hashedPass);
+
+  $rs = mysql_query($queryBuilt, $conn);
+
   session_start();
-  $_SESSION['username'] = $_POST['username'];
+  $_SESSION['username'] = $_POST['email'];
   $_SESSION['otherMessage'] = $other_print;
 
   // Go to the student_view.php file


### PR DESCRIPTION
- Added string validation to make sure it's a valid email in the format 'USER@umbc.edu' to the HTML pages
- Added string validation to PHP
- Changed the names of the form fields for username to reflect that they look for email now.
- Added required flag to all form fields that are required
- Editted the validation PHP pages to work with emails instead.
- Changed the SQL query builders in the validation pages to be more intutive using string formatting.
- Renamed validate_advisor.php and validate_student.php to reflect that they are for when you register students/advisors.
- I still need to finish the rest of the PHP files to work with emails instead of usernames. I'm not sure what that entails.
- I kept the username SESSION variable's name to make it easier.
- There's also a bunch of grungy PHPStorm files that got changed that are in this commit, sorry.